### PR TITLE
Add keys to array type properties

### DIFF
--- a/src/Service/EntityToDtoMapper.php
+++ b/src/Service/EntityToDtoMapper.php
@@ -59,8 +59,8 @@ class EntityToDtoMapper
     {
         if (is_array($from)) {
             $properties = [];
-            foreach ($from as $value) {
-                $properties[] = static::getProperties($value);
+            foreach ($from as $key => $value) {
+                $properties[$key] = static::getProperties($value);
             }
 
             return $properties;


### PR DESCRIPTION
If you have an array property with keys they will be added to the output now.

Before:
```json
"dimensions": [
    "12",
    "3",
    "156"
],
```

After:
```json
"dimensions": {
    "length": "12",
    "width": "3",
    "height": "156"
},
```

